### PR TITLE
Improved library API and added automatic HttpClient disposal

### DIFF
--- a/PlainHttp/HttpClientFactory.cs
+++ b/PlainHttp/HttpClientFactory.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 
@@ -13,11 +15,61 @@ namespace PlainHttp
     /// </summary>
     public class HttpClientFactory : IHttpClientFactory
     {
+        private class HttpClientAndTimestamp
+        {
+            public HttpClient client;
+            public long lastFetchTimestamp; //A return value of Stopwatch.GetTimestamp() to make sure that the timestamp is monotonic.
+            public TimeSpan GetElapsedTimeSpan()
+            {
+                //DateTime.Now is not used because it is not monotonic and it will cause bugs because of that.
+                return TimeSpan.FromSeconds((double)Stopwatch.GetTimestamp() / Stopwatch.Frequency) - TimeSpan.FromSeconds((double)lastFetchTimestamp / Stopwatch.Frequency);
+            }
+        }
+
         /// <summary>
         /// Cache for the clients
         /// </summary>
-        private readonly ConcurrentDictionary<string, HttpClient> clients =
-            new ConcurrentDictionary<string, HttpClient>();
+        private readonly ConcurrentDictionary<string, HttpClientAndTimestamp> clients =
+            new ConcurrentDictionary<string, HttpClientAndTimestamp>();
+
+        private TimeSpan clientStaleTimeout;
+        private int maximumClientCount;
+
+        /// <summary>
+        /// Constructor
+        /// <param name="clientStaleTimeout"><see cref="HttpClient"/> instances will be disposed after not being fetched for the specified amount of time</param>
+        /// <param name="maximumClientCount">Maximum amount of <see cref="HttpClient"/> instances at a given time. If this amount is exceeded, earliest fetched instances will be deleted</param>
+        /// </summary>
+        public HttpClientFactory(TimeSpan clientStaleTimeout, int maximumClientCount)
+        {
+            this.clientStaleTimeout = clientStaleTimeout;
+            this.maximumClientCount = maximumClientCount;
+        }
+
+        /// <summary>
+        /// Disposes old and stale HttpClient instances
+        /// </summary>
+        private void CleanupHttpClientCache()
+        {
+            lock (clients)
+            {
+                foreach (var itemToBeDeleted in clients.Where(x => x.Value.GetElapsedTimeSpan() >= clientStaleTimeout))
+                {
+                    itemToBeDeleted.Value.client.Dispose();
+                    clients.TryRemove(itemToBeDeleted.Key, out _);
+                }
+
+                int requiredClientCountToBeDeleted = clients.Count - maximumClientCount;
+                if (requiredClientCountToBeDeleted > 0)
+                {
+                    foreach (var itemToBeDeleted in clients.OrderBy(x => x.Value.lastFetchTimestamp).Take(requiredClientCountToBeDeleted))
+                    {
+                        itemToBeDeleted.Value.client.Dispose();
+                        clients.TryRemove(itemToBeDeleted.Key, out _);
+                    }
+                }
+            }
+        }
 
         /// <summary>
         /// Gets a cached client for the host associated to the input URL
@@ -41,44 +93,69 @@ namespace PlainHttp
         /// <returns>A cached <see cref="HttpClient"/> instance with a random proxy. Returns null if no proxies are available</returns>
         public HttpClient GetProxiedClient(IWebProxy proxy)
         {
+            if (proxy == null)
+            {
+                throw new ArgumentNullException(nameof(proxy));
+            }
+
             return ProxiedClientFromCache(proxy);
         }
 
         private HttpClient PerHostClientFromCache(Uri uri)
         {
-            return this.clients.AddOrUpdate(
-                key: uri.Host,
-                addValueFactory: u =>
-                {
-                    return CreateClient();
-                },
-                updateValueFactory: (u, client) =>
-                {
-                    return client;
-                }
-            );
+            lock (clients)
+            {
+                var result = this.clients.AddOrUpdate(
+                    key: uri.Host,
+                    addValueFactory: u =>
+                    {
+                        return new HttpClientAndTimestamp()
+                        {
+                            client = CreateClient(),
+                            lastFetchTimestamp = Stopwatch.GetTimestamp()
+                        };
+                    },
+                    updateValueFactory: (u, value) =>
+                    {
+                        return value;
+                    }
+                );
+                result.lastFetchTimestamp = Stopwatch.GetTimestamp();
+                CleanupHttpClientCache();
+                return result.client;
+            }
         }
 
         private HttpClient ProxiedClientFromCache(IWebProxy proxy)
         {
-            return this.clients.AddOrUpdate(
-                key: proxy.GetHashCode().ToString(),
-                addValueFactory: u =>
-                {
-                    return CreateProxiedClient(proxy);
-                },
-                updateValueFactory: (u, client) =>
-                {
-                    return client;
-                }
-            );
+            lock (clients)
+            {
+                var result = this.clients.AddOrUpdate(
+                    key: proxy.GetHashCode().ToString(),
+                    addValueFactory: u =>
+                    {
+                        return new HttpClientAndTimestamp()
+                        {
+                            client = CreateProxiedClient(proxy),
+                            lastFetchTimestamp = Stopwatch.GetTimestamp()
+                        };
+                    },
+                    updateValueFactory: (u, value) =>
+                    {
+                        return value;
+                    }
+                );
+                result.lastFetchTimestamp = Stopwatch.GetTimestamp();
+                CleanupHttpClientCache();
+                return result.client;
+            }
         }
 
         private SocketsHttpHandler GetDefaultHttpMessageHandler()
         {
             return new SocketsHttpHandler()
             {
-                PooledConnectionLifetime = TimeSpan.FromMinutes(10),
+                PooledConnectionLifetime = clientStaleTimeout, //Try to keep the connection open for the lifetime of the HTTP client if no requests are made.
                 UseCookies = false,
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli
             };

--- a/PlainHttp/HttpRequest.cs
+++ b/PlainHttp/HttpRequest.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -34,7 +35,7 @@ namespace PlainHttp
         public Dictionary<string, string> Headers { get; set; }
             = new Dictionary<string, string>();
 
-        public Uri Proxy { get; set; }
+        public IWebProxy Proxy { get; set; }
 
         public object Payload { get; set; }
 
@@ -47,6 +48,8 @@ namespace PlainHttp
         public HttpCompletionOption HttpCompletionOption { get; set; } = HttpCompletionOption.ResponseContentRead;
 
         public bool ReadBody { get; set; } = true;
+
+        public Version HttpVersion { get; set; }
 
         private static AsyncLocal<TestingMode> testingMode
             = new AsyncLocal<TestingMode>();
@@ -104,6 +107,12 @@ namespace PlainHttp
             if (this.Timeout != TimeSpan.Zero)
             {
                 cts.CancelAfter(this.Timeout);
+            }
+
+            // Set the HTTP protocol version to be used
+            if (this.HttpVersion != null)
+            {
+                requestMessage.Version = HttpVersion;
             }
 
             Stopwatch stopwatch = Stopwatch.StartNew();

--- a/PlainHttp/HttpRequest.cs
+++ b/PlainHttp/HttpRequest.cs
@@ -39,7 +39,7 @@ namespace PlainHttp
 
         public object Payload { get; set; }
 
-        public ContentType ContentType { get; set; }
+        public PayloadSerializationType PayloadSerializationType { get; set; }
 
         public string DownloadFileName { get; set; }
 
@@ -124,15 +124,15 @@ namespace PlainHttp
                 // Serialize the payload
                 if (this.Payload != null)
                 {
-                    if (this.ContentType == ContentType.Json)
+                    if (this.PayloadSerializationType == PayloadSerializationType.Json)
                     {
                         SerializeToJson(requestMessage);
                     }
-                    else if (this.ContentType == ContentType.Xml)
+                    else if (this.PayloadSerializationType == PayloadSerializationType.Xml)
                     {
                         SerializeToXml(requestMessage);
                     }
-                    else if (this.ContentType == ContentType.UrlEncoded)
+                    else if (this.PayloadSerializationType == PayloadSerializationType.UrlEncoded)
                     {
                         SerializeToUrlEncoded(requestMessage);
                     }

--- a/PlainHttp/HttpRequest.cs
+++ b/PlainHttp/HttpRequest.cs
@@ -25,7 +25,7 @@ namespace PlainHttp
         public Uri Uri { get; set; }
 
         public static IHttpClientFactory HttpClientFactory { get; set; }
-            = new HttpClientFactory();
+            = new HttpClientFactory(TimeSpan.FromMinutes(10), 1000);
 
         public HttpRequestMessage Message { get; protected set; }
 

--- a/PlainHttp/HttpRequest.cs
+++ b/PlainHttp/HttpRequest.cs
@@ -1,5 +1,4 @@
 ﻿using Flurl.Util;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,6 +6,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -270,7 +270,7 @@ namespace PlainHttp
             }
             else
             {
-                serialized = JsonConvert.SerializeObject(this.Payload);
+                serialized = JsonSerializer.Serialize(this.Payload);
             }
 
             requestMessage.Content = new StringContent(

--- a/PlainHttp/IHttpClientFactory.cs
+++ b/PlainHttp/IHttpClientFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
 
 namespace PlainHttp
@@ -7,6 +8,6 @@ namespace PlainHttp
     {
         HttpClient GetClient(Uri uri);
 
-        HttpClient GetProxiedClient(Uri proxyUri);
+        HttpClient GetProxiedClient(IWebProxy proxy);
     }
 }

--- a/PlainHttp/IHttpRequest.cs
+++ b/PlainHttp/IHttpRequest.cs
@@ -9,7 +9,7 @@ namespace PlainHttp
 {
     public interface IHttpRequest
     {
-        ContentType ContentType { get; set; }
+        PayloadSerializationType PayloadSerializationType { get; set; }
         string DownloadFileName { get; set; }
         Dictionary<string, string> Headers { get; set; }
         HttpRequestMessage Message { get; }

--- a/PlainHttp/IHttpRequest.cs
+++ b/PlainHttp/IHttpRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,11 +15,12 @@ namespace PlainHttp
         HttpRequestMessage Message { get; }
         HttpMethod Method { get; set; }
         object Payload { get; set; }
-        Uri Proxy { get; set; }
+        IWebProxy Proxy { get; set; }
         TimeSpan Timeout { get; set; }
         Uri Uri { get; set; }
         HttpCompletionOption HttpCompletionOption { get; set; }
         bool ReadBody { get; set; }
+        Version HttpVersion { get; set; }
 
         Task<IHttpResponse> SendAsync(CancellationToken cancellationToken = default(CancellationToken));
     }

--- a/PlainHttp/PayloadSerializationType.cs
+++ b/PlainHttp/PayloadSerializationType.cs
@@ -1,6 +1,6 @@
 ﻿namespace PlainHttp
 {
-    public enum ContentType
+    public enum PayloadSerializationType
     {
         Raw,
         Json,

--- a/PlainHttp/PlainHttp.csproj
+++ b/PlainHttp/PlainHttp.csproj
@@ -13,8 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Flurl" Version="3.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Include="Flurl" Version="3.0.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds the first three of the features suggested here: #4

- Added automatic decompression of Brotli.
- Added `HttpVersion` field to `HttpRequest` class to allow changing the HTTP protocol version.
- Renamed `ContentType` field in `HttpRequest` to `PayloadSerializationType` to avoid confusion between ``Content-Type` header.
- Removed Newtonsoft.Json dependency, used `System.Text.Json` instead.
- Updated Flurl dependency.
- Added automatic client disposal to `HttpClientFactory`.
- Changed the `Proxy` field's type in `HttpRequest` to `IWebProxy` to allow user-defined classes to be used.
- Updated README.md accordingly.